### PR TITLE
Use pixels for data-balloon font-size

### DIFF
--- a/_sass/chartButtons.scss
+++ b/_sass/chartButtons.scss
@@ -31,7 +31,7 @@
     display: inline-block;
     &[data-balloon]:before {
       padding: 0.5em;
-      font-size: 0.8em;
+      font-size: 13px;
       border: none;
       box-shadow: none;
       border-radius: 0px;

--- a/_sass/chartButtons.scss
+++ b/_sass/chartButtons.scss
@@ -31,7 +31,7 @@
     display: inline-block;
     &[data-balloon]:before {
       padding: 0.5em;
-      font-size: 13px;
+      font-size: $FONT_SIZE_S;
       border: none;
       box-shadow: none;
       border-radius: 0px;


### PR DESCRIPTION
Since ie renders `em` differently than other browsers, it caused the data-balloon text to me much smaller that it was supposed to be, also was harder too read.